### PR TITLE
APEX REST endpoint for fetching person idents from record ids

### DIFF
--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -69,9 +69,18 @@
       ]
     },
     {
-      "path": "src/integration//audit-logging",
+      "versionName": "ver 0.1",
+      "versionNumber": "0.1.0.NEXT",
+      "path": "src/integration/audit-logging",
+      "default": false,
       "package": "audit-logging",
-      "versionNumber": "0.1.0.NEXT"
+      "versionDescription": "Overføring av logger til ArcSight",
+      "dependencies": [
+        {
+          "package": "crm-platform-base",
+          "versionNumber": "0.253.0.LATEST"
+        }
+      ]
     }
   ],
   "packageAliases": {
@@ -88,6 +97,7 @@
     "crm-shared-flowComponents": "0Ho2o000000fxYJCAY",
     "crm-platform-integration": "0Ho2o0000008ORrCAM",
     "crm-platform-oppgave": "0Ho2o000000fxXzCAI",
-    "crm-platform-reporting": "0Ho2o0000008OSfCAM"
+    "crm-platform-reporting": "0Ho2o0000008OSfCAM",
+    "audit-logging": "0HoQC00000003sL0AQ"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -67,6 +67,11 @@
           "versionNumber": "0.157.0.LATEST"
         }
       ]
+    },
+    {
+      "path": "src/integration//audit-logging",
+      "package": "audit-logging",
+      "versionNumber": "0.1.0.NEXT"
     }
   ],
   "packageAliases": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -69,8 +69,8 @@
       ]
     },
     {
-      "versionName": "ver 0.1",
-      "versionNumber": "0.1.0.NEXT",
+      "versionName": "ver 0.2",
+      "versionNumber": "0.2.0.NEXT",
       "path": "src/integration/audit-logging",
       "default": false,
       "package": "audit-logging",

--- a/src/integration/audit-logging/classes/services/AuditLoggingPersonIdentService.cls
+++ b/src/integration/audit-logging/classes/services/AuditLoggingPersonIdentService.cls
@@ -13,7 +13,8 @@ global with sharing class AuditLoggingPersonIdentService {
             request.personIdentField +
             ' FROM ' +
             request.objectName +
-            ' WHERE Id IN :recordIds';
+            ' WHERE Id IN :recordIds' +
+            ' WITH SECURITY_ENFORCED';
 
         try {
             List<SObject> records = Database.query(soqlQuery);
@@ -21,11 +22,13 @@ global with sharing class AuditLoggingPersonIdentService {
             for (SObject record : records) {
                 PersonIdentResponse response = new PersonIdentResponse();
                 response.recordId = (String) record.get('Id');
-                response.personIdent = (String) record.get(
-                    request.personIdentField
+                response.personIdent = getPersonIdent(
+                    request.personIdentField,
+                    record
                 );
                 responses.add(response);
             }
+
             // Serialize the response to JSON
             setResponse(200, JSON.serialize(responses));
         } catch (Exception e) {
@@ -44,6 +47,26 @@ global with sharing class AuditLoggingPersonIdentService {
         response.statusCode = statusCode;
         response.responseBody = Blob.valueOf(payload);
         response.addHeader('Content-Type', 'application/json');
+    }
+
+    private static String getPersonIdent(
+        String personIdentField,
+        SObject record
+    ) {
+        if (personIdentField.contains('.')) {
+            List<String> parts = personIdentField.split('\\.');
+            SObject related = record;
+            for (Integer i = 0; i < parts.size() - 1; i++) {
+                related = (SObject) related.getSObject(parts[i]);
+                if (related == null)
+                    break;
+            }
+            return (related != null &&
+                related.get(parts[parts.size() - 1]) != null)
+                ? String.valueOf(related.get(parts[parts.size() - 1]))
+                : null;
+        }
+        return (String) record.get(personIdentField);
     }
 
     global class PersonIdentResponse {

--- a/src/integration/audit-logging/classes/services/AuditLoggingPersonIdentService.cls
+++ b/src/integration/audit-logging/classes/services/AuditLoggingPersonIdentService.cls
@@ -1,0 +1,47 @@
+@RestResource(urlMapping='/audit-logging/person-idents')
+global with sharing class AuditLoggingPersonIdentService {
+    @HttpPost
+    global static void getPersonIdents() {
+        PersonIdentRequest request = (PersonIdentRequest) JSON.deserialize(
+            RestContext.request.requestBody.toString(),
+            PersonIdentRequest.class
+        );
+
+        List<String> recordIds = request.recordIds;
+        String soqlQuery =
+            'SELECT Id, ' +
+            request.personIdentField +
+            ' FROM ' +
+            request.objectName +
+            ' WHERE Id IN :recordIds';
+
+        List<SObject> records = Database.query(soqlQuery);
+        List<PersonIdentResponse> responses = new List<PersonIdentResponse>();
+        for (SObject record : records) {
+            PersonIdentResponse response = new PersonIdentResponse();
+            response.recordId = (String) record.get('Id');
+            response.personIdent = (String) record.get(
+                request.personIdentField
+            );
+            responses.add(response);
+        }
+        // Serialize the response to JSON
+        setResponse(200, JSON.serialize(responses));
+    }
+    global class PersonIdentRequest {
+        global String objectName;
+        global String personIdentField;
+        global List<String> recordIds;
+    }
+
+    private static void setResponse(Integer statusCode, String payload) {
+        RestContext.response.statusCode = statusCode;
+        RestContext.response.responseBody = Blob.valueOf(payload);
+        RestContext.response.addHeader('Content-Type', 'application/json');
+    }
+
+    global class PersonIdentResponse {
+        global String recordId;
+        global String personIdent;
+    }
+}

--- a/src/integration/audit-logging/classes/services/AuditLoggingPersonIdentService.cls
+++ b/src/integration/audit-logging/classes/services/AuditLoggingPersonIdentService.cls
@@ -15,18 +15,23 @@ global with sharing class AuditLoggingPersonIdentService {
             request.objectName +
             ' WHERE Id IN :recordIds';
 
-        List<SObject> records = Database.query(soqlQuery);
-        List<PersonIdentResponse> responses = new List<PersonIdentResponse>();
-        for (SObject record : records) {
-            PersonIdentResponse response = new PersonIdentResponse();
-            response.recordId = (String) record.get('Id');
-            response.personIdent = (String) record.get(
-                request.personIdentField
-            );
-            responses.add(response);
+        try {
+            List<SObject> records = Database.query(soqlQuery);
+            List<PersonIdentResponse> responses = new List<PersonIdentResponse>();
+            for (SObject record : records) {
+                PersonIdentResponse response = new PersonIdentResponse();
+                response.recordId = (String) record.get('Id');
+                response.personIdent = (String) record.get(
+                    request.personIdentField
+                );
+                responses.add(response);
+            }
+            // Serialize the response to JSON
+            setResponse(200, JSON.serialize(responses));
+        } catch (Exception e) {
+            // Handle any exceptions and return a 500 status code
+            setResponse(500, e.getMessage());
         }
-        // Serialize the response to JSON
-        setResponse(200, JSON.serialize(responses));
     }
     global class PersonIdentRequest {
         global String objectName;
@@ -35,9 +40,10 @@ global with sharing class AuditLoggingPersonIdentService {
     }
 
     private static void setResponse(Integer statusCode, String payload) {
-        RestContext.response.statusCode = statusCode;
-        RestContext.response.responseBody = Blob.valueOf(payload);
-        RestContext.response.addHeader('Content-Type', 'application/json');
+        RestResponse response = RestContext.response;
+        response.statusCode = statusCode;
+        response.responseBody = Blob.valueOf(payload);
+        response.addHeader('Content-Type', 'application/json');
     }
 
     global class PersonIdentResponse {

--- a/src/integration/audit-logging/classes/services/AuditLoggingPersonIdentService.cls-meta.xml
+++ b/src/integration/audit-logging/classes/services/AuditLoggingPersonIdentService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/integration/audit-logging/classes/services/tests/AuditLoggingPersonIdentServiceTest.cls
+++ b/src/integration/audit-logging/classes/services/tests/AuditLoggingPersonIdentServiceTest.cls
@@ -14,6 +14,12 @@ private class AuditLoggingPersonIdentServiceTest {
             new Account(Name = 'Test Account 3')
         };
         insert accounts;
+
+        Case testCase = new Case(
+            Subject = 'Test Case',
+            AccountId = accounts[0].Id
+        );
+        insert testCase;
     }
 
     @IsTest
@@ -164,5 +170,38 @@ private class AuditLoggingPersonIdentServiceTest {
         String responseBody = RestContext.response.responseBody.toString();
         String expectedErrorMessage = 'No such column \'Unknown\' on entity';
         Assert.isTrue((responseBody.contains(expectedErrorMessage)));
+    }
+
+    @IsTest
+    static void shouldReturnOnePersonIdentsWhenOneCaseIdAsInput() {
+        // Arrange
+        AuditLoggingPersonIdentService.PersonIdentRequest request = new AuditLoggingPersonIdentService.PersonIdentRequest();
+        request.objectName = ' Case';
+        request.personIdentField = 'Account.INT_PersonIdent__c';
+        request.recordIds = new List<Id>{
+            [SELECT Id FROM Case WHERE Subject = 'Test Case']
+            .Id
+        };
+
+        RestContext.request = new RestRequest();
+        RestContext.request.requestBody = Blob.valueOf(JSON.serialize(request));
+
+        // Act
+        Test.startTest();
+        RestContext.response = new RestResponse();
+        AuditLoggingPersonIdentService.getPersonIdents();
+        Test.stopTest();
+
+        // Assert
+        Assert.areEqual(200, RestContext.response.statusCode);
+        String responseBody = RestContext.response.responseBody.toString();
+        Assert.areNotEqual(null, responseBody);
+
+        Assert.areEqual(
+            '[{"recordId":"' +
+                request.recordIds[0] +
+                '","personIdent":"1234567890"}]',
+            responseBody
+        );
     }
 }

--- a/src/integration/audit-logging/classes/services/tests/AuditLoggingPersonIdentServiceTest.cls
+++ b/src/integration/audit-logging/classes/services/tests/AuditLoggingPersonIdentServiceTest.cls
@@ -1,0 +1,54 @@
+@IsTest
+private class AuditLoggingPersonIdentServiceTest {
+    @TestSetup
+    static void makeData() {
+        List<Account> accounts = new List<Account>{
+            new Account(
+                Name = 'Test Account 1',
+                INT_PersonIdent__c = '1234567890'
+            ),
+            new Account(
+                Name = 'Test Account 2',
+                INT_PersonIdent__c = '0987654321'
+            )
+        };
+        insert accounts;
+    }
+
+    @IsTest
+    static void shouldReturnTwoPersonIdentsWhenToRecordIdsAsInput() {
+        // Arrange
+        AuditLoggingPersonIdentService.PersonIdentRequest request = new AuditLoggingPersonIdentService.PersonIdentRequest();
+        request.objectName = 'Account';
+        request.personIdentField = 'INT_PersonIdent__c';
+        request.recordIds = new List<Id>{
+            [SELECT Id FROM Account WHERE Name = 'Test Account 1']
+            .Id,
+            [SELECT Id FROM Account WHERE Name = 'Test Account 2']
+            .Id
+        };
+        system.debug(JSON.serialize(request));
+        RestContext.request = new RestRequest();
+        RestContext.request.requestBody = Blob.valueOf(JSON.serialize(request));
+
+        // Act
+        Test.startTest();
+        RestContext.response = new RestResponse();
+        AuditLoggingPersonIdentService.getPersonIdents();
+        Test.stopTest();
+
+        // Assert
+        Assert.areEqual(200, RestContext.response.statusCode);
+        String responseBody = RestContext.response.responseBody.toString();
+        Assert.areNotEqual(null, responseBody);
+
+        Assert.areEqual(
+            '[{"recordId":"' +
+                request.recordIds[0] +
+                '","personIdent":"1234567890"},{"recordId":"' +
+                request.recordIds[1] +
+                '","personIdent":"0987654321"}]',
+            responseBody
+        );
+    }
+}

--- a/src/integration/audit-logging/classes/services/tests/AuditLoggingPersonIdentServiceTest.cls
+++ b/src/integration/audit-logging/classes/services/tests/AuditLoggingPersonIdentServiceTest.cls
@@ -10,7 +10,8 @@ private class AuditLoggingPersonIdentServiceTest {
             new Account(
                 Name = 'Test Account 2',
                 INT_PersonIdent__c = '0987654321'
-            )
+            ),
+            new Account(Name = 'Test Account 3')
         };
         insert accounts;
     }
@@ -27,7 +28,7 @@ private class AuditLoggingPersonIdentServiceTest {
             [SELECT Id FROM Account WHERE Name = 'Test Account 2']
             .Id
         };
-        system.debug(JSON.serialize(request));
+
         RestContext.request = new RestRequest();
         RestContext.request.requestBody = Blob.valueOf(JSON.serialize(request));
 
@@ -53,6 +54,61 @@ private class AuditLoggingPersonIdentServiceTest {
     }
 
     @IsTest
+    static void shouldReturnNullForPersonIdentWhenAccountIsMissingPersonIdent() {
+        // Arrange
+        AuditLoggingPersonIdentService.PersonIdentRequest request = new AuditLoggingPersonIdentService.PersonIdentRequest();
+        request.objectName = 'Account';
+        request.personIdentField = 'INT_PersonIdent__c';
+        request.recordIds = new List<Id>{
+            [SELECT Id FROM Account WHERE Name = 'Test Account 3']
+            .Id
+        };
+
+        RestContext.request = new RestRequest();
+        RestContext.request.requestBody = Blob.valueOf(JSON.serialize(request));
+
+        // Act
+        Test.startTest();
+        RestContext.response = new RestResponse();
+        AuditLoggingPersonIdentService.getPersonIdents();
+        Test.stopTest();
+
+        // Assert
+        Assert.areEqual(200, RestContext.response.statusCode);
+        String responseBody = RestContext.response.responseBody.toString();
+        Assert.areNotEqual(null, responseBody);
+
+        Assert.areEqual(
+            '[{"recordId":"' + request.recordIds[0] + '","personIdent":null}]',
+            responseBody
+        );
+    }
+
+    @IsTest
+    static void shouldReturnEmptyListWhenRecordIdDoesNotExist() {
+        // Arrange
+        AuditLoggingPersonIdentService.PersonIdentRequest request = new AuditLoggingPersonIdentService.PersonIdentRequest();
+        request.objectName = 'Account';
+        request.personIdentField = 'INT_PersonIdent__c';
+        request.recordIds = new List<Id>{ '001xx000003DGYAAA4' };
+        RestContext.request = new RestRequest();
+        RestContext.request.requestBody = Blob.valueOf(JSON.serialize(request));
+
+        // Act
+        Test.startTest();
+        RestContext.response = new RestResponse();
+        AuditLoggingPersonIdentService.getPersonIdents();
+        Test.stopTest();
+
+        // Assert
+        Assert.areEqual(200, RestContext.response.statusCode);
+        String responseBody = RestContext.response.responseBody.toString();
+        Assert.areNotEqual(null, responseBody);
+
+        Assert.areEqual('[]', responseBody);
+    }
+
+    @IsTest
     static void shouldReturn500StatusCodeWhenUnknownObject() {
         // Arrange
         AuditLoggingPersonIdentService.PersonIdentRequest request = new AuditLoggingPersonIdentService.PersonIdentRequest();
@@ -64,7 +120,7 @@ private class AuditLoggingPersonIdentServiceTest {
             [SELECT Id FROM Account WHERE Name = 'Test Account 2']
             .Id
         };
-        system.debug(JSON.serialize(request));
+
         RestContext.request = new RestRequest();
         RestContext.request.requestBody = Blob.valueOf(JSON.serialize(request));
 
@@ -78,6 +134,35 @@ private class AuditLoggingPersonIdentServiceTest {
         Assert.areEqual(500, RestContext.response.statusCode);
         String responseBody = RestContext.response.responseBody.toString();
         String expectedErrorMessage = 'sObject type \'Account2\' is not supported.';
+        Assert.isTrue((responseBody.contains(expectedErrorMessage)));
+    }
+
+    @IsTest
+    static void shouldReturn500StatusCodeWhenUnknownPersonIdentField() {
+        // Arrange
+        AuditLoggingPersonIdentService.PersonIdentRequest request = new AuditLoggingPersonIdentService.PersonIdentRequest();
+        request.objectName = 'Account';
+        request.personIdentField = 'Unknown';
+        request.recordIds = new List<Id>{
+            [SELECT Id FROM Account WHERE Name = 'Test Account 1']
+            .Id,
+            [SELECT Id FROM Account WHERE Name = 'Test Account 2']
+            .Id
+        };
+
+        RestContext.request = new RestRequest();
+        RestContext.request.requestBody = Blob.valueOf(JSON.serialize(request));
+
+        // Act
+        Test.startTest();
+        RestContext.response = new RestResponse();
+        AuditLoggingPersonIdentService.getPersonIdents();
+        Test.stopTest();
+
+        // Assert
+        Assert.areEqual(500, RestContext.response.statusCode);
+        String responseBody = RestContext.response.responseBody.toString();
+        String expectedErrorMessage = 'No such column \'Unknown\' on entity';
         Assert.isTrue((responseBody.contains(expectedErrorMessage)));
     }
 }

--- a/src/integration/audit-logging/classes/services/tests/AuditLoggingPersonIdentServiceTest.cls
+++ b/src/integration/audit-logging/classes/services/tests/AuditLoggingPersonIdentServiceTest.cls
@@ -51,4 +51,33 @@ private class AuditLoggingPersonIdentServiceTest {
             responseBody
         );
     }
+
+    @IsTest
+    static void shouldReturn500StatusCodeWhenUnknownObject() {
+        // Arrange
+        AuditLoggingPersonIdentService.PersonIdentRequest request = new AuditLoggingPersonIdentService.PersonIdentRequest();
+        request.objectName = 'Account2';
+        request.personIdentField = 'INT_PersonIdent__c';
+        request.recordIds = new List<Id>{
+            [SELECT Id FROM Account WHERE Name = 'Test Account 1']
+            .Id,
+            [SELECT Id FROM Account WHERE Name = 'Test Account 2']
+            .Id
+        };
+        system.debug(JSON.serialize(request));
+        RestContext.request = new RestRequest();
+        RestContext.request.requestBody = Blob.valueOf(JSON.serialize(request));
+
+        // Act
+        Test.startTest();
+        RestContext.response = new RestResponse();
+        AuditLoggingPersonIdentService.getPersonIdents();
+        Test.stopTest();
+
+        // Assert
+        Assert.areEqual(500, RestContext.response.statusCode);
+        String responseBody = RestContext.response.responseBody.toString();
+        String expectedErrorMessage = 'sObject type \'Account2\' is not supported.';
+        Assert.isTrue((responseBody.contains(expectedErrorMessage)));
+    }
 }

--- a/src/integration/audit-logging/classes/services/tests/AuditLoggingPersonIdentServiceTest.cls-meta.xml
+++ b/src/integration/audit-logging/classes/services/tests/AuditLoggingPersonIdentServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Endepunktet brukes av sf-audit-logging for å knytte fødselsnummer til recordIds, som er hentet i Lightning URI Events. Implementasjonen i Salesforce er generisk slik at konfigurasjonen gjøres i NAIS-appen